### PR TITLE
Fixes for ESP8266_RTOS_SDK

### DIFF
--- a/main/interfaces/wifi_esp_now_interface.cpp
+++ b/main/interfaces/wifi_esp_now_interface.cpp
@@ -8,6 +8,10 @@
 #include "../hashes.h"
 #include "net_utils.h"
 
+#include "sdkconfig.h"
+#ifdef CONFIG_IDF_TARGET_ESP8266
+#include <esp_netif.h>
+#endif
 
 using namespace NsWifiEspNowInterface;
 using namespace MeshProto;

--- a/main/platform/esp8266_api.h
+++ b/main/platform/esp8266_api.h
@@ -5,6 +5,7 @@
 #include <freertos/task.h>
 #include <mbedtls/md.h>
 
+#include <esp_timer.h>
 
 namespace Os
 {


### PR DESCRIPTION
Apparently 2 more #include's were required for it to build.