### PR TITLE
Build failed on clang 18.1.8

### DIFF
--- a/main/blob_types.h
+++ b/main/blob_types.h
@@ -4,6 +4,7 @@
 
 #include <bit>
 #include <cstring>
+#include <type_traits>
 
 // waiting for C++23 "deducing this" feature to get implemented...
 // no CRTP, sorry


### PR DESCRIPTION
In clang version 18.1.8 build failed on blob_types.h
```
C:/Users/user/CLionProjects/SmartHome/thirdparties/fresh/main/./blob_types.h:26:48: error: no member named 'is_base_of_v' in namespace 'std'
   26 |     template <typename TStrong> requires (std::is_base_of_v<BaseStrongType, TStrong>)
      |                                           ~~~~~^
C:/Users/user/CLionProjects/SmartHome/thirdparties/fresh/main/./blob_types.h:26:61: error: 'BaseStrongType' does not refer to a value
   26 |     template <typename TStrong> requires (std::is_base_of_v<BaseStrongType, TStrong>)
      |                                                             ^
```
To fix need add include type_traits